### PR TITLE
fix for ws library 3.x

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -72,8 +72,9 @@ function onRequestConnect(info, callback) {
 /**
  * Connection passed through verify, lets initiate a proxy
  */
-function onConnection(ws) {
-
+function onConnection(ws, req) {
+	if (ws.upgradeReq === undefined) 
+		ws.upgradeReq = req;
 	modules.method.connect(ws, function(res) {
 		//All modules have processed the connection, lets start the proxy
 		new Proxy(ws);


### PR DESCRIPTION
when runing proxy with ws lib 3.x it crashes because v3 removed upgradeReq field. see https://github.com/websockets/ws/issues/1114